### PR TITLE
Fixed Controller::controllerId() method, cause when controller name h…

### DIFF
--- a/src/base/Controller.php
+++ b/src/base/Controller.php
@@ -152,7 +152,7 @@ class Controller extends \yii\web\Controller
 
     public static function controllerId()
     {
-        return strtolower(substr(end(explode('\\', get_called_class())), 0, -10)); // todo: remove
+        return Inflector::camel2id(substr(end(explode('\\', get_called_class())), 0, -10)); // todo: remove
     }
 
     /**


### PR DESCRIPTION
…as CamelCase name there is no conversion to controller ID.
E.g.: ModelGroupController converts to `modelgroup` but need `model-group`