### PR TITLE
Fixed countRowsInTableBody

### DIFF
--- a/tests/_support/Page/IndexPage.php
+++ b/tests/_support/Page/IndexPage.php
@@ -148,7 +148,7 @@ class IndexPage extends Authenticated
      */
     public function countRowsInTableBody(): int
     {
-        return count($this->tester->grabMultiple('//tbody/tr'));
+        return count($this->tester->grabMultiple('//tbody/tr[contains(@data-key,*)]'));
     }
 
     /**


### PR DESCRIPTION
If debug yii panel is enabled - count not correct work (counting tr in debug panel)