### PR TITLE
Fixed filters resetting after layout changing

### DIFF
--- a/src/widgets/IndexLayoutSwitcher.php
+++ b/src/widgets/IndexLayoutSwitcher.php
@@ -10,6 +10,7 @@
 
 namespace hipanel\widgets;
 
+use hipanel\helpers\Url;
 use hipanel\models\IndexPageUiOptions;
 use yii\base\Widget;
 use yii\bootstrap\ButtonGroup;
@@ -29,21 +30,34 @@ class IndexLayoutSwitcher extends Widget
             'buttons' => [
                 Html::a(
                     '<i class="fa fa-pause" aria-hidden="true"></i>',
-                    ['index', 'orientation' => IndexPageUiOptions::ORIENTATION_HORIZONTAL],
-                    ['class' => 'btn btn-default btn-sm ' . ($this->isOrientation(IndexPageUiOptions::ORIENTATION_HORIZONTAL) ? 'active' : '')]),
+                    Url::current(['orientation' => IndexPageUiOptions::ORIENTATION_HORIZONTAL]),
+                    ['class' => 'btn btn-default btn-sm ' .
+                            $this->getClassActive(IndexPageUiOptions::ORIENTATION_HORIZONTAL)
+                    ]),
                 Html::a(
                     '<i class="fa fa-pause fa-rotate-90" aria-hidden="true"></i>',
-                    ['index', 'orientation' => IndexPageUiOptions::ORIENTATION_VERTICAL],
-                    ['class' => 'btn btn-default btn-sm ' . ($this->isOrientation(IndexPageUiOptions::ORIENTATION_VERTICAL) ? 'active' : '')]),
+                    Url::current(['orientation' => IndexPageUiOptions::ORIENTATION_VERTICAL]),
+                    ['class' => 'btn btn-default btn-sm ' .
+                            $this->getClassActive(IndexPageUiOptions::ORIENTATION_VERTICAL)
+                    ]),
             ],
         ]);
+    }
+
+    /**
+     * @param string $orientation
+     * @return string
+     */
+    private function getClassActive(string $orientation): string
+    {
+        return $this->isOriented($orientation) ? 'active' : '';
     }
 
     /**
      * @param $orientation
      * @return bool
      */
-    private function isOrientation($orientation)
+    private function isOriented(string $orientation): bool
     {
         return $this->uiModel->orientation === $orientation;
     }


### PR DESCRIPTION
After layout changing the GET parameters of the current URL had been
erasing and filter storage didn't work.