### PR TITLE
Downgraded selenium/standalone-chrome

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   selenium:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.141.0
     volumes:
       - /dev/shm:/dev/shm
 


### PR DESCRIPTION
Downgraded selenium/standalone-chrome to version 3.141.0 due
"[Facebook\WebDriver\Exception\UnrecognizedExceptionException]
invalid argument: invalid 'expiry'"