### PR TITLE
Deleted body-click in Select2

### DIFF
--- a/tests/_support/Page/Widget/Input/Select2.php
+++ b/tests/_support/Page/Widget/Input/Select2.php
@@ -116,7 +116,6 @@ class Select2 extends TestableInput
         });
 JS
         );
-        $this->tester->click('//body');
 
         return $this;
     }


### PR DESCRIPTION
deleted body-click that closed Select2 window but at the same time closed popup with Select2