### PR TITLE
HP-1581: Calling get_class() without arguments is deprecated

### DIFF
--- a/src/widgets/RefFilter.php
+++ b/src/widgets/RefFilter.php
@@ -72,7 +72,7 @@ class RefFilter extends Widget
         if (isset($config['options'])) {
             $options = &$config['options'];
         }
-        $vars = get_class_vars(get_class());
+        $vars = get_class_vars(static::class);
         foreach ($config as $k => $v) {
             if (array_key_exists($k, $vars)) {
                 continue;


### PR DESCRIPTION
https://sentry.hiqdev.com/organizations/hiqdev/issues/58985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the retrieval method for class variables to enhance efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->