### PR TITLE
HP-1581 fix "explode(): Passing null to parameter #2 ($string) of type string is deprecated" warning

### DIFF
--- a/src/widgets/LinkSorter.php
+++ b/src/widgets/LinkSorter.php
@@ -55,7 +55,7 @@ class LinkSorter extends \yii\widgets\LinkSorter
         return $this->render('LinkSorterView', [
             'id' => $this->id,
             'links' => $links,
-            'label' => $this->getSortLabel($this->uiModel->sort),
+            'label' => $this->uiModel->sort ? $this->getSortLabel($this->uiModel->sort) : null,
             'options' => array_merge($this->options, ['encode' => false]),
             'containerClass' => $this->containerClass,
             'buttonClass' => $this->buttonClass,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a9345b96-9571-4eef-ba0c-ea6623f6d78c)
https://sentry.hiqdev.com/organizations/hiqdev/issues/59082