### PR TITLE
HP-2419 fixing 'Failed to open stream' hipanel-module-finance/config/assets-prod.php no such file

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,9 +1,25 @@
+build:
+    environment:
+        php:
+            version: 8.3.3
+    nodes:
+        analysis:
+            tests:
+                override: [ php-scrutinizer-run ]
+
+tools:
+    php_code_coverage:
+        enabled: true
+        external_code_coverage:
+            timeout: 600
+    php_code_sniffer: true
+
+filter:
+    excluded_paths:
+        - tests/*
+        - vendor/*
+
 checks:
     php:
         code_rating: true
         duplication: true
-tools:
-    php_code_coverage:
-        enabled: true
-    external_code_coverage:
-        timeout: 600

--- a/config/web.php
+++ b/config/web.php
@@ -10,6 +10,8 @@
 
 /** @var array $params */
 
+$assetsProd = dirname(__DIR__, 4) . '/config/assets-prod.php';
+
 return [
     'id' => 'hipanel',
     'name' => 'HiPanel',
@@ -111,7 +113,7 @@ return [
             ],
         ],
         'assetManager' => [
-            'bundles' => YII_ENV === 'prod' ? require(dirname(__DIR__, 4) . '/config/assets-prod.php') : [],
+            'bundles' => YII_ENV === 'prod' && file_exists($assetsProd) ? require($assetsProd) : [],
         ],
         'fileStorage' => [
             'class' => \hipanel\components\FileStorage::class,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of asset configuration in production to prevent errors if the asset configuration file is missing.
- **Chores**
  - Enhanced continuous integration configuration with updated PHP version, added code quality tools, and refined analysis filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->