### PR TITLE
HP-2550: Update audit permissions to use 'audit.read' instead of 'aud…

### DIFF
--- a/src/controllers/AuditController.php
+++ b/src/controllers/AuditController.php
@@ -31,8 +31,7 @@ class AuditController extends Controller
                 'class' => EasyAccessControl::class,
                 'actions' => [
                     '*' => [
-//                        'audit.see-everything',
-                        'owner-staff',
+                        'audit.read',
                     ],
                 ],
             ],

--- a/src/widgets/AuditButton.php
+++ b/src/widgets/AuditButton.php
@@ -22,7 +22,7 @@ class AuditButton extends Widget
     public function run(): string
     {
         $user = Yii::$app->user;
-        if (!$user->can('audit.see-everything') || !$user->can('test.beta')) {
+        if (!$user->can('audit.read')) {
             return '';
         }
         $icon = Html::tag('i', '', ['class' => 'fa fa-history fa-fw ' . ($this->rightIcon ? 'pull-right' : '')]);


### PR DESCRIPTION
…it.see-everything'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified access control by consolidating multiple permissions into a single permission requirement for audit-related features.
  * Streamlined permission checks for displaying the audit button, now requiring only one specific permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->