### PR TITLE
master: Replace direct instantiation of `yii\web\Session` with `Yii::…

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -149,7 +149,7 @@ return [
         'singletons' => [
             \hipanel\widgets\filePreview\FilePreviewFactoryInterface::class => \hipanel\widgets\filePreview\FilePreviewFactory::class,
             \yii\web\Session::class => function () {
-                return new \yii\web\Session();
+                return Yii::$app->getSession();
             },
             \yii\web\User::class => function () {
                 return Yii::$app->getUser();


### PR DESCRIPTION
…$app->getSession()` for consistency, this will get rid of `Session is already started` warning and ~23k events in Sentry