### PR TITLE
HP-2717: Add `SwitchLicenceCombo` support to `ObjectCombo` widget

### DIFF
--- a/src/widgets/combo/ObjectCombo.php
+++ b/src/widgets/combo/ObjectCombo.php
@@ -21,6 +21,7 @@ use hipanel\modules\finance\widgets\combo\target\PrivateCloudBackupCombo;
 use hipanel\modules\finance\widgets\combo\target\PrivateCloudCombo;
 use hipanel\modules\finance\widgets\combo\target\SnapshotCombo;
 use hipanel\modules\finance\widgets\combo\target\StorageCombo;
+use hipanel\modules\finance\widgets\combo\target\SwitchLicenceCombo;
 use hipanel\modules\finance\widgets\combo\target\VideoCDNCombo;
 use hipanel\modules\finance\widgets\combo\target\VolumeCombo;
 use hipanel\modules\finance\widgets\combo\target\VPSCombo;
@@ -69,6 +70,7 @@ class ObjectCombo extends InputWidget
     public array $knownClasses = [
         'client' => ['alias' => '@client', 'combo' => ClientCombo::class],
         'partner' => ['alias' => '@client', 'combo' => PartnerCombo::class],
+        'switch_license' => ['alias' => '@target', 'combo' => SwitchLicenceCombo::class],
         'device' => ['alias' => '@server', 'combo' => ServerCombo::class],
         'domain' => ['alias' => '@domain', 'combo' => DomainCombo::class],
         'zone' => ['alias' => '@domain', 'combo' => ZoneCombo::class],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for selecting “Switch License” in object pickers/combo controls. This new option is available wherever the object selection component is used, enabling easier linking and assignment of switch licenses within workflows. Users can now find and choose switch licenses alongside existing object types, improving discoverability and streamlining related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->