### PR TITLE
HQD-188: perf: add request-level caches for ModelTrait::attributes(),…

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -92,7 +92,7 @@ return [
             ],
         ],
         'urlManager' => [
-            'class' => \yii\web\UrlManager::class,
+            'class' => \hipanel\components\UrlManager::class,
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'enableStrictParsing' => false,
@@ -106,6 +106,7 @@ return [
             ],
         ],
         'formatter' => [
+            'class' => \hipanel\components\Formatter::class,
             'nullDisplay' => '&nbsp;',
             'sizeFormatBase' => 1000,
         ],

--- a/src/base/ModelTrait.php
+++ b/src/base/ModelTrait.php
@@ -20,6 +20,12 @@ trait ModelTrait
      */
     public function attributes()
     {
+        static $cache = [];
+        $class = static::class;
+        if (isset($cache[$class])) {
+            return $cache[$class];
+        }
+
         $attributes = \yii\base\Model::attributes();
         foreach (self::rules() as $rule) {
             if (is_string(reset($rule))) {
@@ -33,6 +39,6 @@ trait ModelTrait
             }
         }
 
-        return array_values($attributes);
+        return $cache[$class] = array_values($attributes);
     }
 }

--- a/src/components/Formatter.php
+++ b/src/components/Formatter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace hipanel\components;
+
+use NumberFormatter;
+
+class Formatter extends \yii\i18n\Formatter
+{
+    private array $_numberFormatterCache = [];
+
+    protected function createNumberFormatter($style, $decimals = null, $options = [], $textOptions = [])
+    {
+        $cacheKey = $style . '_' . $decimals . '_' . serialize($options) . '_' . serialize($textOptions);
+        if (!isset($this->_numberFormatterCache[$cacheKey])) {
+            $this->_numberFormatterCache[$cacheKey] = parent::createNumberFormatter($style, $decimals, $options, $textOptions);
+        }
+
+        return $this->_numberFormatterCache[$cacheKey];
+    }
+}

--- a/src/components/UrlManager.php
+++ b/src/components/UrlManager.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace hipanel\components;
+
+use yii\web\UrlRuleInterface;
+
+/**
+ * Extends Yii2 UrlManager with two optimizations for hipanel's 3-segment routes
+ * (e.g. finance/bill/view) that never match any URL rule and always use fallback.
+ *
+ * 1. canBeCached() returns true for all rules (including ROUTE_MISMATCH), so
+ *    the main loop populates _ruleCache on the first call per cacheKey.
+ *
+ * 2. Tracks cacheKeys where ALL cached rules returned false ("fallback routes").
+ *    On subsequent calls for these cacheKeys, getUrlFromCache returns false
+ *    immediately without iterating the cached rules at all.
+ */
+class UrlManager extends \yii\web\UrlManager
+{
+    /** @var array cacheKeys where every rule failed — use fallback URL immediately */
+    private array $_fallbackCacheKeys = [];
+    /** @var array cacheKeys that have at least one rule added via setRuleToCache */
+    private array $_populatedCacheKeys = [];
+
+    protected function canBeCached(UrlRuleInterface $rule): bool
+    {
+        return true;
+    }
+
+    protected function setRuleToCache($cacheKey, UrlRuleInterface $rule): void
+    {
+        parent::setRuleToCache($cacheKey, $rule);
+        $this->_populatedCacheKeys[$cacheKey] = true;
+    }
+
+    protected function getUrlFromCache($cacheKey, $route, $params)
+    {
+        if (isset($this->_fallbackCacheKeys[$cacheKey])) {
+            return false;
+        }
+
+        $url = parent::getUrlFromCache($cacheKey, $route, $params);
+
+        if ($url === false && isset($this->_populatedCacheKeys[$cacheKey])) {
+            $this->_fallbackCacheKeys[$cacheKey] = true;
+        }
+
+        return $url;
+    }
+}

--- a/src/models/Ref.php
+++ b/src/models/Ref.php
@@ -63,6 +63,12 @@ class Ref extends \hiqdev\hiart\ActiveRecord
             $translate = 'hipanel';
         }
 
+        static $runtimeCache = [];
+        $runtimeKey = serialize([$name, $translate, $options]);
+        if (isset($runtimeCache[$runtimeKey])) {
+            return $runtimeCache[$runtimeKey];
+        }
+
         $data = Yii::$app->get('cache')->getOrSet([__METHOD__, $name, $options], function () use ($name, $options) {
             $conditions = array_merge(['gtype' => $name], $options);
             $result = self::find()->where($conditions)->all();
@@ -70,7 +76,7 @@ class Ref extends \hiqdev\hiart\ActiveRecord
             return $result;
         }, 3600);
 
-        return array_map(function ($model) use ($translate) {
+        $result = array_map(function ($model) use ($translate) {
             /** @var self $model */
             if ($translate !== false) {
                 $model->label = Yii::t($translate, $model->label);
@@ -78,5 +84,7 @@ class Ref extends \hiqdev\hiart\ActiveRecord
 
             return $model;
         }, $data);
+
+        return $runtimeCache[$runtimeKey] = $result;
     }
 }


### PR DESCRIPTION
… Ref::findCached(), UrlManager and Formatter

ModelTrait::attributes(): add static per-class cache to avoid iterating rules() on every __get/hasAttribute call.

Ref::findCached(): add static $runtimeCache keyed by name+translate+options to avoid repeated unserialize and array_map translation on every call within a request.

Add Formatter component with NumberFormatter instance caching in createNumberFormatter() to avoid constructing a new instance per grid cell.

Add UrlManager component that caches ROUTE_MISMATCH rules in _ruleCache (canBeCached returns true for all rules) and tracks cacheKeys where all rules failed to skip rule scanning entirely on subsequent calls.