### PR TITLE
Fix flaky acceptance tests: wait for page content, not a fixed sleep

### DIFF
--- a/tests/_support/Helper/CredentialsProvider.php
+++ b/tests/_support/Helper/CredentialsProvider.php
@@ -89,6 +89,18 @@ class CredentialsProvider extends \Codeception\Module
             // request that fires after the initial navigation - without this,
             // callers race the content load and intermittently see a not-yet-filled
             // page (see ContactsCest flake).
+            //
+            // Waiting for "idle" alone isn't enough: jQuery.active is still 0
+            // until that request actually starts, so checking idle first can
+            // pass instantly, before the request was even dispatched. Wait for
+            // it to start first (tolerating pages with no pjax/AJAX content at
+            // all) and only then wait for it to finish.
+            try {
+                $wd->waitForJS('return !!window.jQuery && window.jQuery.active > 0;', 1);
+            } catch (\Facebook\WebDriver\Exception\TimeoutException $e) {
+                // No pjax/AJAX request started within the grace window - this
+                // page has no further async content to wait out.
+            }
             $wd->waitForJS('return document.readyState === "complete" && (!window.jQuery || window.jQuery.active === 0);', 10);
         }
     }

--- a/tests/_support/Helper/CredentialsProvider.php
+++ b/tests/_support/Helper/CredentialsProvider.php
@@ -84,6 +84,12 @@ class CredentialsProvider extends \Codeception\Module
         }
         if ($currentUrl !== $url) {
             $wd->amOnPage($url);
+            // The layout shell loads synchronously, but page content (e.g. the h1
+            // callers check right after needPage()) is filled in by a pjax/AJAX
+            // request that fires after the initial navigation - without this,
+            // callers race the content load and intermittently see a not-yet-filled
+            // page (see ContactsCest flake).
+            $wd->waitForJS('return document.readyState === "complete" && (!window.jQuery || window.jQuery.active === 0);', 10);
         }
     }
 

--- a/tests/_support/Page/Login.php
+++ b/tests/_support/Page/Login.php
@@ -34,7 +34,7 @@ class Login
         $I->fillField('#loginform-username', $login);
         $I->fillField('#loginform-password', $password);
         $I->click('#login-form button[type=submit]');
-        $I->wait(3);
+        $I->waitForPageUpdate();
         $I->see($login);
 
         return $this;

--- a/tests/_support/Page/Login.php
+++ b/tests/_support/Page/Login.php
@@ -34,6 +34,11 @@ class Login
         $I->fillField('#loginform-username', $login);
         $I->fillField('#loginform-password', $password);
         $I->click('#login-form button[type=submit]');
+        // Wait for the post-login redirect itself (a concrete marker) before
+        // falling back to the generic ajax-idle wait - waitForPageUpdate() alone
+        // can finish before the redirect even starts, for the same reason
+        // needPage() needed a "wait for busy first" fix (see CredentialsProvider).
+        $I->waitForJS('return window.location.pathname !== "/site/login";', 10);
         $I->waitForPageUpdate();
         $I->see($login);
 


### PR DESCRIPTION
## Summary
- `CredentialsProvider::needPage()` navigates via `amOnPage()` and returns immediately, before pjax/AJAX-loaded page content settles. Dozens of Cest files across `hipanel-module-client`/`hipanel-module-finance` check for content right after `needPage()` and intermittently race the load (e.g. `ContactsCest`'s "h1 not found" flake, seen in CI: https://git.hiqdev.com/ahnames/hipanel.ahnames.com/-/jobs/661888).
- `Login::login()` had the same class of bug: a fixed `wait(3)` after submitting the login form instead of waiting for the AJAX request, which flaked under slower CI runs (`FinanceSidebarMenuCest`, job 661890).
- Both now use the same JS-readiness wait already established via `WaitHelper::waitForPageUpdate()` elsewhere in this codebase, instead of a guessed fixed sleep.

## Test plan
- [ ] Re-run the acceptance suites that previously flaked (`cc/ahnames/hipanel`, `cc/hiqdev/finance`) a few times to confirm the race is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-loading synchronization after navigation and login submissions.
  * Reduced timing-related test failures by waiting for page updates and completed background requests instead of relying on fixed delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->