### PR TITLE
fix: increase waitForElement timeout in SidebarMenu

### DIFF
--- a/tests/_support/Page/SidebarMenu.php
+++ b/tests/_support/Page/SidebarMenu.php
@@ -26,7 +26,7 @@ class SidebarMenu extends Authenticated
         $I = $this->tester;
 
         $I->click($rootMenuName, '.sidebar-menu');
-        $I->waitForElement('.menu-open');
+        $I->waitForElement('.menu-open', 10);
         foreach ($items as $name => $url) {
             $I->see($name, '.menu-open');
             $I->seeElement(['css' => '.menu-open a[href~="' . Url::to($url) . '"]']);
@@ -42,7 +42,7 @@ class SidebarMenu extends Authenticated
             $I->dontSee($rootMenuName);
         } else {
             $I->click($rootMenuName, '.sidebar-menu');
-            $I->waitForElement('.menu-open');
+            $I->waitForElement('.menu-open', 10);
             foreach ($items as $name) {
                 $I->dontSee($name, '.menu-open');
             }


### PR DESCRIPTION
## Description
Increases explicit timeout in `SidebarMenu::ensureContains` and `SidebarMenu::ensureDoesNotContain` for `waitForElement('.menu-open', 10)`.

## Root Cause
Default `waitForElement` timeout in Codeception WebDriver is 5 seconds. During headless test runs on busy CI runners, AdminLTE sidebar slide animations can take slightly longer than 5 seconds, causing flaky `TimeoutException` failures in `TicketSidebarMenuCest` and `DomainSidebarMenuCest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved sidebar menu validation reliability by allowing up to 10 seconds for expanded menu content to appear after selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->