### PR TITLE
fix: increase waitForJS timeout to 30s and catch background AJAX time…

### DIFF
--- a/tests/_support/Helper/CredentialsProvider.php
+++ b/tests/_support/Helper/CredentialsProvider.php
@@ -101,7 +101,11 @@ class CredentialsProvider extends \Codeception\Module
                 // No pjax/AJAX request started within the grace window - this
                 // page has no further async content to wait out.
             }
-            $wd->waitForJS('return document.readyState === "complete" && (!window.jQuery || window.jQuery.active === 0);', 10);
+            try {
+                $wd->waitForJS('return document.readyState === "complete" && (!window.jQuery || window.jQuery.active === 0);', 30);
+            } catch (\Facebook\WebDriver\Exception\TimeoutException $e) {
+                // Ignore background polling timeouts
+            }
         }
     }
 


### PR DESCRIPTION
…outs in CredentialsProvider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page loading reliability by allowing more time for asynchronous readiness checks.
  * Prevents background polling timeouts from interrupting page navigation when the page is otherwise usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->