### PR TITLE
HQD-292: Drop serverAddr() lookup from network response logging

### DIFF
--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -92,11 +92,12 @@ function isAuthFileExpired(filePath) {
 }
 
 function attachNetworkResponseListener(page) {
-  let isClosed = false;
-  page.on("close", () => { isClosed = true; });
-
-  page.on("response", async (response) => {
-    if (isClosed) return;
+  // Deliberately synchronous: an earlier version awaited response.serverAddr()
+  // to log the server IP, which raced against page/context teardown and
+  // intermittently crashed tests (response.serverAddr: Target page, context
+  // or browser has been closed). Logging nothing but data already on hand
+  // removes that race entirely instead of guarding around it.
+  page.on("response", (response) => {
     const resourceType = response.request().resourceType();
     if (resourceType !== "xhr" && resourceType !== "fetch") return;
 
@@ -106,14 +107,7 @@ function attachNetworkResponseListener(page) {
     const method = response.request().method();
     const status = response.status();
 
-    const serverInfo = await Promise.race([
-      response.serverAddr(),
-      new Promise(resolve => setTimeout(() => resolve(null), 5000)), // Timeout after 5 seconds
-    ]);
-
-    const serverIp = serverInfo?.ipAddress || "Unknown";
-
-    console.log(`${serverIp} - ${formattedDate} "${method} ${path}" ${status}`);
+    console.log(`${formattedDate} "${method} ${path}" ${status}`);
   });
 }
 


### PR DESCRIPTION
attachNetworkResponseListener awaited response.serverAddr() to include the server IP in each logged line. That await was the only async work in the handler, and it raced against page/context teardown: if the page closed while serverAddr() was in flight, it rejected with "Target page, context or browser has been closed" and crashed the test rather than just skipping a log line. A prior fix (HQD-220) added an isClosed guard, but it only checked before the await started, so the same crash resurfaced (HQD-292's original CI failure) whenever the close happened during the await instead of before it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network response logging reliability during page or context shutdown.
  * Prevented race conditions caused by asynchronous server address lookups.
  * Simplified logged response details to include the timestamp, request method, path, and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->