### PR TITLE
HQD-307: Wait for sidebar submenu to close before the next toggle

### DIFF
--- a/tests/_support/Page/SidebarMenu.php
+++ b/tests/_support/Page/SidebarMenu.php
@@ -32,6 +32,7 @@ class SidebarMenu extends Authenticated
             $I->seeElement(['css' => '.menu-open a[href~="' . Url::to($url) . '"]']);
         }
         $I->click($rootMenuName, '.sidebar-menu');
+        $I->waitForElementNotVisible('.menu-open', 10);
     }
 
     public function ensureDoesNotContain(string $rootMenuName, array $items = null): void
@@ -47,6 +48,7 @@ class SidebarMenu extends Authenticated
                 $I->dontSee($name, '.menu-open');
             }
             $I->click($rootMenuName, '.sidebar-menu');
+            $I->waitForElementNotVisible('.menu-open', 10);
         }
     }
 


### PR DESCRIPTION
ensureContains() and ensureDoesNotContain() issue back-to-back clicks to close then reopen a submenu, with no wait in between. The close animation can still be in flight when the reopen click fires, so the following waitForElement('.menu-open') times out. Wait for '.menu-open' to disappear after each close click before proceeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar menu checks by waiting for the menu to finish collapsing before verifying its contents.
  * Increased reliability when confirming items are visible or hidden in the collapsed sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->