### PR TITLE
HQD-322: fix UserMenu header rendering a nonexistent gravatar view

### DIFF
--- a/src/views/menus/userMenuHeader.php
+++ b/src/views/menus/userMenuHeader.php
@@ -1,9 +1,10 @@
 <?php
 
+use hipanel\widgets\Gravatar;
 use yii\helpers\Html;
 
 ?>
-<?= $this->render('//layouts/gravatar', [
+<?= Gravatar::widget([
     'email' => Yii::$app->user->identity->email ?? null,
     'size'  => 90,
 ]) ?>


### PR DESCRIPTION
userMenuHeader.php called $this->render('//layouts/gravatar', ...), which resolves (per this package's own config/web.php viewPath override) to vendor/hiqdev/hisite/src/views/layouts/gravatar.php - a file that has never existed in hisite's history. NavbarMenu includes UserMenu unconditionally (no guest check), so any site whose layout uses NavbarMenu and doesn't force a login before rendering it hits yii\base\ViewNotFoundException on every single page.

hipanel\widgets\Gravatar already exists and already handles the null-email (anonymous user) case correctly (see "Fix gravatar when user has no email", 7e63c8bb) - render the gravatar through that widget instead of the missing view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the user menu avatar rendering for improved consistency.
  * Avatars continue to display using the authenticated user’s email at the existing size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->