### PR TITLE
HQD-328: register AbstractNavbarMenu/AbstractSidebarMenu as singletons

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -137,12 +137,6 @@ return [
     ],
     'container' => [
         'definitions' => [
-            \hiqdev\thememanager\menus\AbstractNavbarMenu::class => [
-                'class' => \hipanel\menus\NavbarMenu::class,
-            ],
-            \hiqdev\thememanager\menus\AbstractSidebarMenu::class => [
-                'class' => \hipanel\menus\SidebarMenu::class,
-            ],
             \hipanel\widgets\AdBanner::class => [
                 'items' => $params['ad-banner.dashboard.items'],
             ],
@@ -151,6 +145,25 @@ return [
             ],
         ],
         'singletons' => [
+            // Registered as singletons, not definitions, so that a consuming app's own
+            // navbar/sidebar override (e.g. hiqdev/hipanel-site's AbstractNavbarMenu
+            // singleton, meant to replace this admin-panel navbar with a public-site one)
+            // reliably wins regardless of composer-config-plugin's per-project package
+            // merge order. yii\di\Container applies a later 'singletons' entry for the
+            // same class over an earlier one via ordinary associative-array merge, but
+            // when the two competing registrations land in *different* sections
+            // ('definitions' vs 'singletons'), which section's value survives depends on
+            // that project-specific merge order instead of composer dependency order -
+            // see ahnames/ahnames.com HQD-328, where this 'definitions' registration
+            // silently won over hipanel-site's singleton override, so the selling site
+            // rendered this admin-panel navbar (complete with its UserMenu/gravatar
+            // dropdown) instead of hipanel-site's plain Login/Panel/Logout link.
+            \hiqdev\thememanager\menus\AbstractNavbarMenu::class => [
+                'class' => \hipanel\menus\NavbarMenu::class,
+            ],
+            \hiqdev\thememanager\menus\AbstractSidebarMenu::class => [
+                'class' => \hipanel\menus\SidebarMenu::class,
+            ],
             \hipanel\widgets\filePreview\FilePreviewFactoryInterface::class => \hipanel\widgets\filePreview\FilePreviewFactory::class,
             \yii\web\Session::class => function () {
                 return Yii::$app->getSession();

--- a/config/web.php
+++ b/config/web.php
@@ -137,6 +137,19 @@ return [
     ],
     'container' => [
         'definitions' => [
+            // AbstractSidebarMenu stays a *definition*, not a singleton: unlike
+            // AbstractNavbarMenu below, it's an actively-used extension point - many
+            // hipanel-module-* packages (finance, client, domain, hosting, ticket, ...)
+            // each contribute their own sidebar item via an 'add'-only 'definitions'
+            // entry for this same class (no 'class' key of their own). Moving the base
+            // 'class' registration to 'singletons' would strand it in a different
+            // section from all of those 'add' contributions - whichever section a
+            // project's merge order applies last would end up with an 'add'-only
+            // definition and no 'class' at all, throwing NotInstantiableException
+            // (confirmed breaking hipanel.ahnames.com when this was tried).
+            \hiqdev\thememanager\menus\AbstractSidebarMenu::class => [
+                'class' => \hipanel\menus\SidebarMenu::class,
+            ],
             \hipanel\widgets\AdBanner::class => [
                 'items' => $params['ad-banner.dashboard.items'],
             ],
@@ -145,24 +158,23 @@ return [
             ],
         ],
         'singletons' => [
-            // Registered as singletons, not definitions, so that a consuming app's own
-            // navbar/sidebar override (e.g. hiqdev/hipanel-site's AbstractNavbarMenu
-            // singleton, meant to replace this admin-panel navbar with a public-site one)
-            // reliably wins regardless of composer-config-plugin's per-project package
-            // merge order. yii\di\Container applies a later 'singletons' entry for the
-            // same class over an earlier one via ordinary associative-array merge, but
-            // when the two competing registrations land in *different* sections
+            // Registered as a singleton, not a definition, so that a consuming app's own
+            // navbar override (e.g. hiqdev/hipanel-site's AbstractNavbarMenu singleton,
+            // meant to replace this admin-panel navbar with a public-site one) reliably
+            // wins regardless of composer-config-plugin's per-project package merge
+            // order. yii\di\Container applies a later 'singletons' entry for the same
+            // class over an earlier one via ordinary associative-array merge, but when
+            // the two competing registrations land in *different* sections
             // ('definitions' vs 'singletons'), which section's value survives depends on
             // that project-specific merge order instead of composer dependency order -
             // see ahnames/ahnames.com HQD-328, where this 'definitions' registration
             // silently won over hipanel-site's singleton override, so the selling site
             // rendered this admin-panel navbar (complete with its UserMenu/gravatar
-            // dropdown) instead of hipanel-site's plain Login/Panel/Logout link.
+            // dropdown) instead of hipanel-site's plain Login/Panel/Logout link. Unlike
+            // AbstractSidebarMenu above, nothing else contributes an 'add'-only
+            // 'definitions' entry for this class, so this move is safe on its own.
             \hiqdev\thememanager\menus\AbstractNavbarMenu::class => [
                 'class' => \hipanel\menus\NavbarMenu::class,
-            ],
-            \hiqdev\thememanager\menus\AbstractSidebarMenu::class => [
-                'class' => \hipanel\menus\SidebarMenu::class,
             ],
             \hipanel\widgets\filePreview\FilePreviewFactoryInterface::class => \hipanel\widgets\filePreview\FilePreviewFactory::class,
             \yii\web\Session::class => function () {


### PR DESCRIPTION
## Summary
- `AbstractNavbarMenu`/`AbstractSidebarMenu` were registered under container `definitions`, while consuming apps (e.g. `hiqdev/hipanel-site`) override them as `singletons` specifically to survive composer package merge order - see hipanel-site's own comment on its `AbstractMainMenu`/`AbstractNavbarMenu`/`AbstractFooterMenu` singletons: *"yii\di\Container applies 'singletons' after 'definitions', ... otherwise [the] generic singleton defaults ... win regardless of composer package merge order."*
- That assumption doesn't hold when the two competing registrations for the same class land in **different** sections: which section's value survives turned out to depend on the consuming project's own package merge order, not composer dependency order.
- In `ahnames/ahnames.com` (HQD-328), this `definitions` registration silently won over hipanel-site's singleton override, so the selling site rendered **this admin-panel navbar** (complete with its UserMenu/gravatar dropdown, which the selling site doesn't even use) instead of hipanel-site's plain Login/Panel/Logout link - and that misrouted admin navbar is what actually hit HQD-322 (missing gravatar view) and the still-open yii2-thememanager HQD-328 (missing UserMenu widget view). Neither of those bugs is ever triggered by a real `hipanel.*` panel deployment, since it's *supposed* to render this navbar.

## Fix
Move both registrations to `singletons`, putting them in the same section as consuming apps' overrides, so a later-loaded app's override reliably wins via ordinary associative-array merge (last value for the same key wins) - regardless of per-project merge-order differences between `definitions` and `singletons`.

## Test plan
- [ ] A real `hipanel.*` panel deployment (no override) still renders this navbar unchanged
- [ ] `ahnames.com` (hipanel-site override present) renders `hipanel\site\menus\NavbarMenu` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in navbar and sidebar menu behavior across the application.
  - Standardized how navigation components are made available and customized by consuming applications.
  - Clarified customization precedence so application-specific navbar settings are applied predictably.
  - Preserved flexible sidebar extension behavior for tailored navigation experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->