### PR TITLE
HQD-328: restore img-circle class on the UserMenu header gravatar

### DIFF
--- a/src/views/menus/userMenuHeader.php
+++ b/src/views/menus/userMenuHeader.php
@@ -7,6 +7,9 @@ use yii\helpers\Html;
 <?= Gravatar::widget([
     'email' => Yii::$app->user->identity->email ?? null,
     'size'  => 90,
+    'options' => [
+        'class' => 'img-circle',
+    ],
 ]) ?>
 <?php if (!is_null(Yii::$app->user->identity)) : ?>
 <p>


### PR DESCRIPTION
Follow-up to #364.

#364 replaced `$this->render('//layouts/gravatar', ...)` (a view that never
existed for hisite-based consuming apps, e.g. ahnames.com) with
`Gravatar::widget()`, fixing the `ViewNotFoundException`. But it dropped the
`'class' => 'img-circle'` option that every other gravatar render in this
codebase passes — see `yii2-theme-adminlte`'s own
`src/views/layouts/gravatar.php`, which defaults `options.class` to
`'img-circle'` unless the caller overrides it.

`.navbar-nav > .user-menu > .dropdown-menu > li.user-header > img` in
AdminLTE.css sizes/positions this 90px avatar via a plain element selector,
but the circular shape comes purely from Bootstrap's `.img-circle` utility
(`border-radius: 50%`). Without that class, the avatar renders as a square in
the dropdown header — a visible regression on the real admin panel navbar,
confirmed by testing against hipanel.ahnames.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the user menu avatar to display as a circular image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->