### PR TITLE
HQD-372: CSRF token self-healing on AJAX 400 errors

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -25,6 +25,7 @@ return [
         'themeManager' => 'themeManager',
         'language' => 'language',
         'timezone',
+        'csrfRetry',
     ]),
     'aliases' => [
         '@ref' => '/ref',
@@ -32,6 +33,7 @@ return [
     ],
     'components' => [
         'timezone' => ['class' => hipanel\components\Timezone::class],
+        'csrfRetry' => ['class' => hipanel\components\CsrfRetry::class],
         'request' => [
             'enableCsrfCookie' => false,
             'cookieValidationKey' => $params['cookieValidationKey'],

--- a/src/actions/CsrfTokenAction.php
+++ b/src/actions/CsrfTokenAction.php
@@ -19,10 +19,21 @@ class CsrfTokenAction extends Action
     public function run(): array
     {
         Yii::$app->response->format = Response::FORMAT_JSON;
+        // Per-session, must never be cached by a shared/intermediate cache or the
+        // browser's back-forward cache - a stale cached token would just fail
+        // validation again, defeating the whole point of this endpoint.
+        Yii::$app->response->getHeaders()->set('Cache-Control', 'no-store, private');
 
         return [
             'csrfParam' => Yii::$app->request->csrfParam,
-            'csrfToken' => Yii::$app->request->getCsrfToken(true),
+            // Forcing regeneration (true) here would mint a brand-new token on every
+            // call, so two concurrent refresh requests (multiple tabs, several failed
+            // POSTs at once) would race to overwrite each other's token in the
+            // session - the token an earlier response already handed to a client
+            // would go stale again before that client's retry even lands. Returning
+            // the existing (or freshly-generated-only-if-missing) token instead keeps
+            // it shared and valid for every concurrent caller.
+            'csrfToken' => Yii::$app->request->getCsrfToken(),
         ];
     }
 }

--- a/src/actions/CsrfTokenAction.php
+++ b/src/actions/CsrfTokenAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\actions;
+
+use Yii;
+use yii\base\Action;
+use yii\web\Response;
+
+/**
+ * Forces a fresh CSRF token (discarding whatever is currently stored - see
+ * Request::getCsrfToken()'s $regenerate param) and returns it as JSON, so a
+ * client that just got a "Unable to verify your data submission" 400 can
+ * fetch a valid token and retry instead of failing outright.
+ */
+class CsrfTokenAction extends Action
+{
+    public function run(): array
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+
+        return [
+            'csrfParam' => Yii::$app->request->csrfParam,
+            'csrfToken' => Yii::$app->request->getCsrfToken(true),
+        ];
+    }
+}

--- a/src/components/CsrfRetry.php
+++ b/src/components/CsrfRetry.php
@@ -28,26 +28,54 @@ class CsrfRetry extends Component
             /** @var View $view */
             $view = $event->sender->view;
             $csrfTokenUrl = Url::to('/site/csrf-token');
+            // Yii's own CSRF-check message (Controller::beforeAction(), 'yii' category) -
+            // translated per the app's language, so a plain-English match would silently
+            // stop matching once the site isn't in English (this app's default language
+            // is 'ru' - see config/web.php). Listing the shipped translations this app
+            // actually uses is more resilient than string-matching a single locale; an
+            // untranslated/new locale just falls back to today's broader (still POST +
+            // same-origin gated) behavior instead of breaking.
+            $csrfMessages = json_encode([
+                // Source string, from yii\web\Controller::beforeAction().
+                'Unable to verify your data submission.',
+                // vendor/yiisoft/yii2/messages/ru/yii.php
+                'Не удалось проверить переданные данные.',
+                // vendor/yiisoft/yii2/messages/uk/yii.php
+                'Не вдалося перевірити передані дані.',
+            ]);
             $js = /** @lang JavaScript */ "
               ;(() => {
                 var refreshing = false;
+                var queue = [];
+                var csrfMessages = $csrfMessages;
                 $(document).ajaxError(function (event, jqXHR, settings) {
                   if (
                     jqXHR.status !== 400 ||
                     settings._csrfRetried ||
-                    refreshing ||
                     !settings.type ||
                     settings.type.toUpperCase() !== 'POST' ||
-                    settings.url.indexOf('$csrfTokenUrl') !== -1
+                    settings.crossDomain ||
+                    settings.url.indexOf('$csrfTokenUrl') !== -1 ||
+                    !jqXHR.responseJSON ||
+                    csrfMessages.indexOf(jqXHR.responseJSON.message) === -1
                   ) {
+                    return;
+                  }
+                  queue.push(settings);
+                  if (refreshing) {
                     return;
                   }
                   refreshing = true;
                   $.get('$csrfTokenUrl', function (data) {
                     yii.setCsrfToken(data.csrfParam, data.csrfToken);
-                    refreshing = false;
-                    $.ajax($.extend({}, settings, { _csrfRetried: true }));
+                    var pending = queue;
+                    queue = [];
+                    pending.forEach(function (queuedSettings) {
+                      $.ajax($.extend({}, queuedSettings, { _csrfRetried: true }));
+                    });
                   }).fail(function () {
+                    queue = [];
+                  }).always(function () {
                     refreshing = false;
                   });
                 });

--- a/src/components/CsrfRetry.php
+++ b/src/components/CsrfRetry.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\components;
+
+use hipanel\helpers\Url;
+use Yii;
+use yii\base\Application;
+use yii\base\Component;
+use yii\web\View;
+
+/**
+ * A stale/mismatched session (multiple tabs, a page served from cache, a request that
+ * raced an earlier request's session write, ...) makes the CSRF token embedded in the
+ * page's meta tags fail validation server-side, even though nothing legitimately wrong
+ * happened - see hipanel\actions\TimeZoneAction's automatic POST for the most visible
+ * case of this. Rather than surface that as a dead-end 400 to every visitor who hits it,
+ * fetch a fresh token from CsrfTokenAction and retry the failed request once.
+ */
+class CsrfRetry extends Component
+{
+    public function init()
+    {
+        parent::init();
+
+        Yii::$app->on(Application::EVENT_BEFORE_REQUEST, function ($event) {
+            /** @var View $view */
+            $view = $event->sender->view;
+            $csrfTokenUrl = Url::to('/site/csrf-token');
+            $js = /** @lang JavaScript */ "
+              ;(() => {
+                var refreshing = false;
+                $(document).ajaxError(function (event, jqXHR, settings) {
+                  if (
+                    jqXHR.status !== 400 ||
+                    settings._csrfRetried ||
+                    refreshing ||
+                    !settings.type ||
+                    settings.type.toUpperCase() !== 'POST' ||
+                    settings.url.indexOf('$csrfTokenUrl') !== -1
+                  ) {
+                    return;
+                  }
+                  refreshing = true;
+                  $.get('$csrfTokenUrl', function (data) {
+                    yii.setCsrfToken(data.csrfParam, data.csrfToken);
+                    refreshing = false;
+                    $.ajax($.extend({}, settings, { _csrfRetried: true }));
+                  }).fail(function () {
+                    refreshing = false;
+                  });
+                });
+              })();
+            ";
+            $view->registerJs($js);
+        });
+    }
+}

--- a/src/controllers/SiteController.php
+++ b/src/controllers/SiteController.php
@@ -10,6 +10,7 @@
 
 namespace hipanel\controllers;
 
+use hipanel\actions\CsrfTokenAction;
 use hipanel\actions\TimeZoneAction;
 use hipanel\helpers\UserHelper;
 use hipanel\logic\Impersonator;
@@ -97,6 +98,10 @@ class SiteController extends \hisite\controllers\SiteController
                 ],
             ],
             'timezone' => TimeZoneAction::class,
+            // GET, not POST - deliberately: it needs to be reachable even when the client's
+            // current CSRF token has gone stale/mismatched (that's the whole point of it),
+            // and GET requests aren't subject to Yii's CSRF check to begin with.
+            'csrf-token' => CsrfTokenAction::class,
         ]);
     }
 

--- a/src/controllers/SiteController.php
+++ b/src/controllers/SiteController.php
@@ -21,6 +21,7 @@ use Yii;
 use hiam\authclient\AuthAction;
 use yii\base\Module;
 use yii\filters\AccessControl;
+use yii\filters\VerbFilter;
 
 /**
  * Site controller.
@@ -51,6 +52,17 @@ class SiteController extends \hisite\controllers\SiteController
                         'allow' => true,
                         'roles' => ['@'],
                     ],
+                ],
+            ],
+            // 'csrf-token' is documented as GET-only below (in actions()) but nothing
+            // enforced that - a POST here with a still-valid token would slip past
+            // Yii's own CSRF check and reach the action anyway, regenerating the
+            // token as an unintended side effect of a request that was never
+            // supposed to route here.
+            'verbs' => [
+                'class' => VerbFilter::class,
+                'actions' => [
+                    'csrf-token' => ['get'],
                 ],
             ],
         ]);


### PR DESCRIPTION
New CsrfRetry component: on any AJAX 400, fetches a fresh CSRF token via a new GET-only site/csrf-token action, updates the page's meta tag, and retries the original request once (guarded against infinite loops/concurrent refreshes). New CsrfTokenAction added to SiteController.

See HQD-372.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery for expired or invalid CSRF tokens during POST requests.
  - Failed submissions can refresh the security token and retry once automatically.
  - Added a secure endpoint for retrieving refreshed CSRF tokens.
  - Improved CSRF error recognition across English, Russian, and Ukrainian responses.
  - Prevented duplicate token refreshes when multiple requests fail simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->