### PR TITLE
HQD-353: feat(http query) added

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -33,6 +33,7 @@ return [
     'components' => [
         'timezone' => ['class' => hipanel\components\Timezone::class],
         'request' => [
+            'class' => \hipanel\components\Request::class,
             'enableCsrfCookie' => false,
             'cookieValidationKey' => $params['cookieValidationKey'],
         ],

--- a/src/actions/DataExportAction.php
+++ b/src/actions/DataExportAction.php
@@ -30,10 +30,8 @@ abstract class DataExportAction extends Action
         $request = $this->controller->request;
         // $request->get() already includes HTTP QUERY method bodies when the consuming
         // app's request component is hipanel\components\Request (its getQueryParams()
-        // merges the QUERY body over the URL query string). POST is kept here for
-        // callers that still submit large parameter sets (e.g. a big `ids` selection)
-        // via POST instead of QUERY.
-        $params = $request->get(null, []) + $request->post(null, []);
+        // merges the QUERY body over the URL query string).
+        $params = $request->get(null, []);
 
         $exporter = $this->exporterFactory->build($this->exportType);
         $this->formatter = $exporter::applyExportFormatting();

--- a/src/actions/DataExportAction.php
+++ b/src/actions/DataExportAction.php
@@ -28,6 +28,11 @@ abstract class DataExportAction extends Action
     public function run(): Response
     {
         $request = $this->controller->request;
+        // $request->get() already includes HTTP QUERY method bodies when the consuming
+        // app's request component is hipanel\components\Request (its getQueryParams()
+        // merges the QUERY body over the URL query string). POST is kept here for
+        // callers that still submit large parameter sets (e.g. a big `ids` selection)
+        // via POST instead of QUERY.
         $params = $request->get(null, []) + $request->post(null, []);
 
         $exporter = $this->exporterFactory->build($this->exportType);

--- a/src/components/Request.php
+++ b/src/components/Request.php
@@ -32,6 +32,26 @@ class Request extends \yii\web\Request
     }
 
     /**
+     * QUERY's CSRF-safe exemption must only apply to a genuine QUERY request —
+     * block any `_method`/`X-Http-Method-Override` attempt to spoof into it,
+     * since those are ordinary write requests (e.g. a forged cross-site POST)
+     * that would otherwise bypass CSRF validation entirely.
+     *
+     * @return string the request method (e.g. GET, POST, HEAD, PUT, PATCH, DELETE, QUERY).
+     */
+    public function getMethod()
+    {
+        $rawMethod = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
+        if ($rawMethod === 'QUERY') {
+            return 'QUERY';
+        }
+
+        $method = parent::getMethod();
+
+        return $method === 'QUERY' ? $rawMethod : $method;
+    }
+
+    /**
      * For QUERY requests, merges the parsed request body into the query params,
      * with body values taking precedence over the URL query string on key collision.
      * Behavior for all other methods is unchanged from the parent class.

--- a/src/components/Request.php
+++ b/src/components/Request.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * HiPanel core package
  *
@@ -9,6 +11,8 @@
  */
 
 namespace hipanel\components;
+
+use yii\base\InvalidConfigException;
 
 /**
  * Extends the base Yii2 request with support for the HTTP QUERY method —
@@ -33,13 +37,14 @@ class Request extends \yii\web\Request
      * Behavior for all other methods is unchanged from the parent class.
      *
      * @return array the request GET parameter values.
+     * @throws InvalidConfigException
      */
     public function getQueryParams()
     {
         $params = parent::getQueryParams();
 
         if ($this->getMethod() === 'QUERY') {
-            $params = array_merge($params, (array) $this->getBodyParams());
+            $params = array_merge($params, (array)$this->getBodyParams());
         }
 
         return $params;

--- a/src/components/Request.php
+++ b/src/components/Request.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * HiPanel core package
+ *
+ * @link      https://hipanel.com/
+ * @package   hipanel-core
+ * @license   BSD-3-Clause
+ * @copyright Copyright (c) 2014-2019, HiQDev (http://hiqdev.com/)
+ */
+
+namespace hipanel\components;
+
+/**
+ * Extends the base Yii2 request with support for the HTTP QUERY method —
+ * a safe, idempotent method that carries its query in the request body.
+ *
+ * @see https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-04.html
+ */
+class Request extends \yii\web\Request
+{
+    public function init()
+    {
+        parent::init();
+
+        if (!in_array('QUERY', $this->csrfTokenSafeMethods, true)) {
+            $this->csrfTokenSafeMethods[] = 'QUERY';
+        }
+    }
+
+    /**
+     * For QUERY requests, merges the parsed request body into the query params,
+     * with body values taking precedence over the URL query string on key collision.
+     * Behavior for all other methods is unchanged from the parent class.
+     *
+     * @return array the request GET parameter values.
+     */
+    public function getQueryParams()
+    {
+        $params = parent::getQueryParams();
+
+        if ($this->getMethod() === 'QUERY') {
+            $params = array_merge($params, (array) $this->getBodyParams());
+        }
+
+        return $params;
+    }
+}

--- a/tests/unit/components/RequestTest.php
+++ b/tests/unit/components/RequestTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace hipanel\tests\unit\components;
+
+use hipanel\components\Request;
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $_GET = [];
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        unset($_POST['_method']);
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = [];
+        unset($_SERVER['REQUEST_METHOD']);
+        unset($_POST['_method']);
+    }
+
+    public function testQueryMethodMergesBodyOverUrlParams(): void
+    {
+        $_GET = ['foo' => 'from-url', 'onlyUrl' => '1'];
+
+        $request = new Request();
+        $request->setRawBody('foo=from-body&onlyBody=1');
+
+        $params = $request->getQueryParams();
+
+        $this->assertSame('from-body', $params['foo'], 'body value must override URL value on key collision');
+        $this->assertSame('1', $params['onlyUrl'], 'URL-only keys must survive the merge');
+        $this->assertSame('1', $params['onlyBody'], 'body-only keys must be present in the merge');
+    }
+
+    public function testQueryMethodIsCsrfSafeByDefault(): void
+    {
+        $request = new Request();
+
+        $this->assertContains('QUERY', $request->csrfTokenSafeMethods);
+        $this->assertTrue($request->validateCsrfToken('does-not-matter'));
+    }
+
+    public function testNonQueryMethodBehavesLikeParent(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET = ['foo' => 'from-url'];
+
+        $request = new Request();
+        $request->setRawBody('foo=from-body&onlyBody=1');
+
+        $this->assertSame(['foo' => 'from-url'], $request->getQueryParams());
+    }
+}

--- a/tests/unit/components/RequestTest.php
+++ b/tests/unit/components/RequestTest.php
@@ -53,4 +53,46 @@ class RequestTest extends TestCase
 
         $this->assertSame(['foo' => 'from-url'], $request->getQueryParams());
     }
+
+    public function testMethodOverrideViaPostCannotClaimQuery(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['_method'] = 'QUERY';
+        $_GET = ['foo' => 'from-url'];
+
+        $request = new Request();
+        $request->setRawBody('foo=from-body&onlyBody=1');
+
+        $this->assertSame(
+            'POST',
+            $request->getMethod(),
+            'a POST request must not be able to spoof its way into the QUERY CSRF exemption via _method'
+        );
+        $this->assertSame(
+            ['foo' => 'from-url'],
+            $request->getQueryParams(),
+            'query params must not be merged with the body when QUERY is only claimed via _method override'
+        );
+    }
+
+    public function testMethodOverrideViaHeaderCannotClaimQuery(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET = ['foo' => 'from-url'];
+
+        $request = new Request();
+        $request->headers->set('X-Http-Method-Override', 'QUERY');
+        $request->setRawBody('foo=from-body&onlyBody=1');
+
+        $this->assertSame(
+            'GET',
+            $request->getMethod(),
+            'a GET request must not be able to spoof its way into the QUERY CSRF exemption via X-Http-Method-Override'
+        );
+        $this->assertSame(
+            ['foo' => 'from-url'],
+            $request->getQueryParams(),
+            'query params must not be merged with the body when QUERY is only claimed via X-Http-Method-Override'
+        );
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `QUERY` requests, including combined URL and request-body parameters.
  - Request-body values take precedence when parameter names overlap.
  - `QUERY` requests are treated as CSRF-safe.

- **Bug Fixes**
  - Data exports now consistently include parameters from supported request sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->