### PR TITLE
HQD-399: revert authClientCollection to a plain array

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -79,36 +79,21 @@ return [
                 ],
             ],
         ],
-        // A closure, not a plain array: hiam.site must stay a bare hostname (see the
-        // '@HIAM_SITE' alias above), but HiamClient::init() unconditionally prepends
-        // 'https://' to any 'site' value that doesn't already contain '://' - breaking
-        // local dev (no real TLS). Deciding the scheme from YII_ENV doesn't work either:
-        // beta/k8s deployments still terminate real TLS despite not being YII_ENV=prod,
-        // so "not prod -> http" is wrong there too. This whole array is otherwise
-        // resolved once at composer-config-plugin build time (no live request exists
-        // yet), so a closure is the only way to check the *actual* current request's
-        // scheme instead of guessing from environment.
-        'authClientCollection' => function () use ($params) {
-            // A Closure component definition is a factory whose return value IS the
-            // component instance (yii\di\Container::invoke() uses it as-is) - unlike a
-            // plain config array, it does NOT get passed through Yii::createObject()
-            // for us, so we have to call that ourselves here.
-            return Yii::createObject([
-                'class' => \hiam\authclient\Collection::class,
-                'clients' => [
-                    'hiam' => array_filter([
-                        'class' => \hiam\authclient\HiamClient::class,
-                        'scope' => $params['hiam.scope'],
-                        'site' => (Yii::$app->request->getIsSecureConnection() ? 'https://' : 'http://') . $params['hiam.site'],
-                        'authUrl' => $params['hiam.authUrl'],
-                        'tokenUrl' => $params['hiam.tokenUrl'],
-                        'apiBaseUrl' => $params['hiam.apiBaseUrl'],
-                        'clientId' => $params['hiam.client_id'],
-                        'clientSecret' => $params['hiam.client_secret'],
-                    ]),
-                ],
-            ]);
-        },
+        'authClientCollection' => [
+            'class' => \hiam\authclient\Collection::class,
+            'clients' => [
+                'hiam' => array_filter([
+                    'class' => \hiam\authclient\HiamClient::class,
+                    'scope' => $params['hiam.scope'],
+                    'site' => $params['hiam.site'],
+                    'authUrl' => $params['hiam.authUrl'],
+                    'tokenUrl' => $params['hiam.tokenUrl'],
+                    'apiBaseUrl' => $params['hiam.apiBaseUrl'],
+                    'clientId' => $params['hiam.client_id'],
+                    'clientSecret' => $params['hiam.client_secret'],
+                ]),
+            ],
+        ],
         'urlManager' => [
             'class' => \hipanel\components\UrlManager::class,
             'enablePrettyUrl' => true,


### PR DESCRIPTION
HQD-375 (36be4d85) turned authClientCollection into a closure so it could derive the hiam.site scheme from the live request instead of always forcing https. That broke downstream packages (e.g. advancedhosters/yii-asset-advancedhosting) that merge their own auth clients into this same 'clients' array via composer-config-plugin's array deep-merge: a closure can't be merged with an array, so the later-loaded package's config silently replaced this one wholesale, dropping the 'hiam' client entirely and breaking login with "Unknown auth client 'hiam'".

The scheme-detection this closure existed for is redundant: it already lives in HiamClient::init() (yii2-hiam-authclient), which derives http(s) from the live request at construction time regardless of how 'site' reaches it. Redoing it here was also unguarded against 'site' already containing a scheme, unlike HiamClient::init().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication service configuration by preserving the configured site address exactly as entered.
  * Prevented automatic changes to the site address based on whether the current connection uses HTTP or HTTPS.
  * Authentication requests now use the configured endpoint consistently across connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->