### PR TITLE
HQD-385: Fix advanced-search sidebar being unusably narrow on sub-120…

### DIFF
--- a/src/widgets/IndexPage.php
+++ b/src/widgets/IndexPage.php
@@ -237,6 +237,38 @@ JS
             .horizontal-view .content-sidebar__inner .btn-group > a.btn {
                 width: 100%;
             }
+            @media (min-width: 1200px) {
+                .horizontal-view .horizontal-content {
+                    display: flex;
+                }
+                .horizontal-view .horizontal-content > .col-lg-2 {
+                    flex: 0 0 280px;
+                    width: 280px;
+                }
+                .horizontal-view .horizontal-content > .col-lg-10 {
+                    flex: 1 1 auto;
+                    width: auto;
+                }
+            }
+            .horizontal-view .content-sidebar .select2-selection--multiple .select2-selection__rendered:has(.select2-selection__choice) {
+                display: flex;
+                flex-direction: column;
+            }
+            .horizontal-view .content-sidebar .select2-selection--multiple .select2-selection__choice {
+                display: flex;
+                align-items: center;
+                width: 100%;
+                max-width: 100%;
+                box-sizing: border-box;
+                margin-left: 0;
+            }
+            .horizontal-view .content-sidebar .select2-selection--multiple .select2-selection__choice__display {
+                flex: 1 1 auto;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
 CSS
         );
     }

--- a/src/widgets/views/IndexPage/horizontal.php
+++ b/src/widgets/views/IndexPage/horizontal.php
@@ -5,7 +5,7 @@ $widget = $this->context;
 ?>
 <div class="horizontal-view">
     <div class="row horizontal-content clearfix">
-        <div class="col-md-2">
+        <div class="col-lg-2">
             <div class="content-sidebar">
                 <div class="content-sidebar__inner clearfix">
                     <?= $widget->renderExportProgress() ?>
@@ -28,7 +28,7 @@ $widget = $this->context;
                 </div>
             </div>
         </div>
-        <div class="col-md-10">
+        <div class="col-lg-10">
             <div class="box box-widget">
                 <div class="box-body no-padding">
                     <div class="mailbox-controls">


### PR DESCRIPTION
…0px viewports

Stack the sidebar and content columns full-width below 1200px instead of squeezing the filters into a ~2/12 column; give the sidebar a fixed 280px width above 1200px instead of a fluid percentage. Also make multi-select choices in the sidebar stack in a column with ellipsis truncation once the selection is non-empty, so long values (e.g. emails) don't overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved the horizontal index page layout on large screens with a fixed-width sidebar and flexible content area.
  * Updated responsive behavior so the two-column layout begins at larger viewport sizes.
  * Stacked sidebar selections vertically and truncated long labels with ellipses for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->