### PR TITLE
HQD-389: submit destination field with shift enter

### DIFF
--- a/src/widgets/AdvancedSearchActiveField.php
+++ b/src/widgets/AdvancedSearchActiveField.php
@@ -76,15 +76,20 @@ class AdvancedSearchActiveField extends ActiveField
      */
     private function registerShiftEnterSubmit()
     {
-        $formId = $this->form->getId();
-        $selector = "#$formId [data-autosize]";
+        $formId = $this->form->options['id'];
+        $formIdJs = \yii\helpers\Json::encode($formId);
         $js = <<<JS
-$(document).on('keydown', '$selector', function (e) {
-    if (e.key === 'Enter' && e.shiftKey) {
-        e.preventDefault();
-        $(this).closest('form').trigger('submit');
+(function () {
+    var form = document.getElementById($formIdJs);
+    if (form) {
+        $(form).on('keydown', '[data-autosize]', function (e) {
+            if (e.key === 'Enter' && e.shiftKey) {
+                e.preventDefault();
+                $(form).trigger('submit');
+            }
+        });
     }
-});
+})();
 JS;
         $this->form->getView()->registerJs($js, \yii\web\View::POS_READY, 'advanced-search-textarea-shift-enter-' . $formId);
     }

--- a/src/widgets/AdvancedSearchActiveField.php
+++ b/src/widgets/AdvancedSearchActiveField.php
@@ -69,18 +69,24 @@ class AdvancedSearchActiveField extends ActiveField
     /**
      * Advanced search textareas accept multiple newline-separated values, so a plain Enter
      * must keep inserting a newline. Shift+Enter submits the search instead.
+     *
+     * Scoped to this form's own id (rather than the bare `[data-autosize]` attribute) so the
+     * behavior stays tied to advanced-search forms, not to every future textarea that happens
+     * to reuse the autosize attribute elsewhere.
      */
     private function registerShiftEnterSubmit()
     {
+        $formId = $this->form->getId();
+        $selector = "#$formId [data-autosize]";
         $js = <<<JS
-$(document).on('keydown', '[data-autosize]', function (e) {
+$(document).on('keydown', '$selector', function (e) {
     if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault();
         $(this).closest('form').trigger('submit');
     }
 });
 JS;
-        $this->form->getView()->registerJs($js, \yii\web\View::POS_READY, 'advanced-search-textarea-shift-enter');
+        $this->form->getView()->registerJs($js, \yii\web\View::POS_READY, 'advanced-search-textarea-shift-enter-' . $formId);
     }
 
     protected function getInputId()

--- a/src/widgets/AdvancedSearchActiveField.php
+++ b/src/widgets/AdvancedSearchActiveField.php
@@ -57,12 +57,30 @@ class AdvancedSearchActiveField extends ActiveField
     public function textarea($options = [])
     {
         AutosizeAsset::activate($this->form->getView(), '[data-autosize]');
+        $this->registerShiftEnterSubmit();
 
         return parent::textarea(ArrayHelper::merge([
             'data-autosize' => true, 'rows' => 1,
             'placeholder' => $this->model->getAttributeLabel($this->attribute),
             'style' => ['max-height' => '30vh'],
         ], $options));
+    }
+
+    /**
+     * Advanced search textareas accept multiple newline-separated values, so a plain Enter
+     * must keep inserting a newline. Shift+Enter submits the search instead.
+     */
+    private function registerShiftEnterSubmit()
+    {
+        $js = <<<JS
+$(document).on('keydown', '[data-autosize]', function (e) {
+    if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        $(this).closest('form').trigger('submit');
+    }
+});
+JS;
+        $this->form->getView()->registerJs($js, \yii\web\View::POS_READY, 'advanced-search-textarea-shift-enter');
     }
 
     protected function getInputId()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shift+Enter support for submitting searches from multi-line search fields.
  * Automatically sized search fields now submit through their associated form when Shift+Enter is pressed.

* **Bug Fixes**
  * Plain Enter continues to insert a new line, preserving expected multi-line text entry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->